### PR TITLE
Fixed a crash caused by invalid background colours being specified

### DIFF
--- a/yaircc/UI/IRCTabPage.cs
+++ b/yaircc/UI/IRCTabPage.cs
@@ -862,9 +862,12 @@ namespace Yaircc.UI
                                 }
 
                                 currentForegroundColour = int.Parse(match.Groups["foreground"].Value);
-
+                                
                                 if (currentForegroundColour >= 0 && currentForegroundColour <= 16)
                                 {
+                                    // Reset any background colour higher than 16 to -1.
+                                    currentBackgroundColour = currentBackgroundColour > 16 ? -1 : currentBackgroundColour;
+
                                     string newTag = string.Empty;
                                     newTag = string.Format(
                                         "<span style=\"color: {0}; background-color: {1};\">",


### PR DESCRIPTION
If a background colour outside the ranges defined by mIRC are used the program would crash, such as in the below example:

> # GreenPeace.et 11 users0,11æ,12,11`æ11,12æ,2,12`æ12,2æ,0,2`æ2,17æ  1 Welcome toogPeace11.:. 1Current Lineup : eraz, nTo, VerMu, sCope, robaciek,staminaboy/Bu: Flashy,xAeee 11.:.2,17`æ0,2æ,12,2`æ,11,12`æ12,11æ,back 6 january

Should this happen now, the default background colour will be used instead, as per the guidelines on this matter from mIRC.
